### PR TITLE
A couple of bug fixes

### DIFF
--- a/eeprom.h
+++ b/eeprom.h
@@ -25,18 +25,20 @@
 
 
 
-/* ----------- Exported typedefs ------------- */
+/* ----------- Exported constants ------------- */
 
-
-
+#define PAGE_SIZE		0x40
+#define PAGE_MASK		(PAGE_SIZE-1)
 
 /* ----------- Exported functions prototypes ------------- */
 
 extern void eeprom_init(void);
 extern bool eeprom_write_byte(uint16_t, uint8_t);
 extern bool eeprom_write_page(uint16_t, uint8_t *, uint16_t);
+extern bool eeprom_write_block(uint16_t, uint8_t *, uint16_t);
 extern bool eeprom_read_byte(uint16_t, uint8_t *);
 extern bool eeprom_read_page(uint16_t, uint8_t *, uint16_t);
+extern bool eeprom_read_block(uint16_t, uint8_t *, uint16_t);
 
 
 


### PR DESCRIPTION
Hi Marco, and thanks for the great library. I made a couple of improvements, hope you'll accept them:

1. The write_page and read_page functions should be restricted to one page only, the eeprom does not support multiple pages in one transaction. If you try to cross the page boundary the address will wrap around to the beginning of the page.
2. I added write_block and read_block functions which can cross the page boundaries, they call write_page and read_page as many times as necessary. 
3. Every time you send the address to the I2C bus, you should check for the SR1_AF bit, otherwise you'll wait forever if the device fail to respond for some reason.

Regards,
Dima.